### PR TITLE
remove body-parser package , and implement express bodyparser

### DIFF
--- a/Server/package.json
+++ b/Server/package.json
@@ -9,7 +9,6 @@
   "author": "Deepak",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "ejs": "^3.1.5",

--- a/Server/server.js
+++ b/Server/server.js
@@ -1,6 +1,5 @@
 const express=require('express');
 const app=express();
-const bodyparser=require('body-parser');
 const connection=require('./connection');
 const Post=require('./routes/route');
 const cors = require('cors');
@@ -12,8 +11,8 @@ path=require('path');
 app.use(fileupload());
 app.set('views', __dirname + '/views');
 app.use(cors());
-app.use(bodyparser.urlencoded({ extended: true })); 
-app.use(bodyparser.json());
+app.use(express.urlencoded()); 
+app.use(express.json());
 app.use('/post',Post);
 app.set('view engine', 'ejs');
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
removed the unneeded bodyparser package  and impleted all its features using express , thus reducing the dependencies size.